### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This ACF field type is only compatible with ACF 5
 * Fix to work with Repeater Field
 
 **1.1.0**
-* Changed code to fix issue with special charachters in tooltip 
+* Changed code to fix issue with special characters in tooltip 
 
 **1.0.1**
 * Small bugfixes


### PR DESCRIPTION
@tmconnect, I've corrected a typographical error in the documentation of the [ACF-Tooltip](https://github.com/tmconnect/ACF-Tooltip) project. Specifically, I've changed charachter to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.